### PR TITLE
Don't refresh clock speeds when not necessary #28 #31

### DIFF
--- a/src/Core/Overlay.cpp
+++ b/src/Core/Overlay.cpp
@@ -480,7 +480,7 @@ void Overlay::UpdateInfoThread(uint64_t arg)
 
       g_Overlay.m_PayloadVersion = GetPayloadVersion();
 
-      if (!g_Config.overlay.showClockSpeeds)
+      if (g_Config.overlay.showClockSpeeds)
       {
         g_Overlay.m_CpuClock = g_Overlay.GetCpuClockSpeed();
         g_Overlay.m_GpuClock = g_Overlay.GetGpuClockSpeed();

--- a/src/Core/Overlay.cpp
+++ b/src/Core/Overlay.cpp
@@ -6,7 +6,9 @@ Overlay g_Overlay;
 Overlay::Overlay()
 {
     m_ReloadConfigTime = GetTimeNow() + 10000;
-    sys_ppu_thread_create(&LoadExternalOffsetsThreadId, LoadExternalOffsets, 0, 0xB02, 512, SYS_PPU_THREAD_CREATE_JOINABLE, "Overlay::LoadExternalOffsets()");
+
+    if (g_Config.overlay.showClockSpeeds) // find clock speed offsets only when they are displayed
+        sys_ppu_thread_create(&LoadExternalOffsetsThreadId, LoadExternalOffsets, 0, 0xB02, 512, SYS_PPU_THREAD_CREATE_JOINABLE, "Overlay::LoadExternalOffsets()");
 
     sys_ppu_thread_create(&UpdateInfoThreadId, UpdateInfoThread, 0, 0xB01, 512, SYS_PPU_THREAD_CREATE_JOINABLE, "Overlay::UpdateInfoThread()");
 }
@@ -482,9 +484,9 @@ void Overlay::UpdateInfoThread(uint64_t arg)
 
       if (g_Config.overlay.showClockSpeeds)
       {
-        g_Overlay.m_CpuClock = g_Overlay.GetCpuClockSpeed();
-        g_Overlay.m_GpuClock = g_Overlay.GetGpuClockSpeed();
-        g_Overlay.m_GpuGddr3RamClock = g_Overlay.GetGpuGddr3RamClockSpeed();
+          g_Overlay.m_CpuClock = g_Overlay.GetCpuClockSpeed();
+          g_Overlay.m_GpuClock = g_Overlay.GetGpuClockSpeed();
+          g_Overlay.m_GpuGddr3RamClock = g_Overlay.GetGpuGddr3RamClockSpeed();
       }
 
       g_Overlay.WaitAndQueueTextInLV2();

--- a/src/Core/Overlay.cpp
+++ b/src/Core/Overlay.cpp
@@ -480,9 +480,12 @@ void Overlay::UpdateInfoThread(uint64_t arg)
 
       g_Overlay.m_PayloadVersion = GetPayloadVersion();
 
-      g_Overlay.m_CpuClock = g_Overlay.GetCpuClockSpeed();
-      g_Overlay.m_GpuClock = g_Overlay.GetGpuClockSpeed();
-      g_Overlay.m_GpuGddr3RamClock = g_Overlay.GetGpuGddr3RamClockSpeed();
+      if (!g_Config.overlay.showClockSpeeds)
+      {
+        g_Overlay.m_CpuClock = g_Overlay.GetCpuClockSpeed();
+        g_Overlay.m_GpuClock = g_Overlay.GetGpuClockSpeed();
+        g_Overlay.m_GpuGddr3RamClock = g_Overlay.GetGpuGddr3RamClockSpeed();
+      }
 
       g_Overlay.WaitAndQueueTextInLV2();
 


### PR DESCRIPTION
This patch allows to prevent a crash occuring due to clock speed readouts on specific PS3 models by not calling affected functions  when user disables it with "showClockSpeeds: Off" in the config.


Related to issues #28 and #31 